### PR TITLE
Add a counter for zombie allocs and skip them

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -396,7 +396,7 @@ func (e *Exporter) collectAllocations(nodes nodeMap, ch chan<- prometheus.Metric
 	}
 
 	var w sync.WaitGroup
-	allocationZombies.Reset()
+	allocationZombies.Set(0)
 
 	for _, allocStub := range allocStubs {
 		w.Add(1)
@@ -408,7 +408,7 @@ func (e *Exporter) collectAllocations(nodes nodeMap, ch chan<- prometheus.Metric
 			if n == nil {
 				logrus.Debugf("Allocation %s doesn't have a node associated. Skipping",
 					allocStub.ID)
-				allocationZombies.With(prometheus.Labels{}).Add(1)
+				allocationZombies.Add(1)
 				return
 			}
 

--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -101,12 +101,11 @@ var (
 		"Allocation throttled CPU.",
 		[]string{"job", "group", "alloc", "region", "datacenter", "node"}, nil,
 	)
-	allocationZombies = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	allocationZombies = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "allocation_zombies",
 		Help:      "Allocation zombies.",
 	},
-		nil,
 	)
 	taskCPUTotalTicks = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "task_cpu_total_ticks"),

--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -101,6 +101,13 @@ var (
 		"Allocation throttled CPU.",
 		[]string{"job", "group", "alloc", "region", "datacenter", "node"}, nil,
 	)
+	allocationZombies = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "allocation_zombies",
+		Help:      "Allocation zombies.",
+	},
+		nil,
+	)
 	taskCPUTotalTicks = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "task_cpu_total_ticks"),
 		"Task CPU total ticks.",


### PR DESCRIPTION
**This is based on version 0.0.7** so I'm not too sure which base branch should I point it to.

In some extreme cases an allocation can be orphaned. That is, it doesn't have a node associated. We can't be sure about its state, whether it's running or not, but the most important thing is that `allocStub.NodeID` is empty and we're assuming that it's not, which leads to a segfault.

This patch notices the pitfall before we dive in it and, while we're at it, adds a new metric that can be useful to trigger an alert.