### PR TITLE
Add some Serf metrics

### DIFF
--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -56,6 +56,36 @@ var (
 		"Describe member state.",
 		[]string{"datacenter", "class", "node", "drain"}, nil,
 	)
+	raftAppliedIndex = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_applied_index"),
+		"Index being applied.",
+		[]string{"datacenter", "node"}, nil,
+	)
+	raftCommitIndex = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_commit_index"),
+		"Index being committed.",
+		[]string{"datacenter", "node"}, nil,
+	)
+	raftFsmPending = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_fsm_pending"),
+		"Pending FSM.",
+		[]string{"datacenter", "node"}, nil,
+	)
+	raftLastLogIndex = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_last_log_index"),
+		"Last log index.",
+		[]string{"datacenter", "node"}, nil,
+	)
+	raftLastSnapshotIndex = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_last_snapshot_index"),
+		"Last snapshot index.",
+		[]string{"datacenter", "node"}, nil,
+	)
+	raftNumPeers = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "raft_num_peers"),
+		"Number of Raft peers.",
+		[]string{"datacenter", "node"}, nil,
+	)
 	jobsTotal = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "jobs_total"),
 		"How many jobs are there in the cluster.",
@@ -327,6 +357,7 @@ func main() {
 			"allow-stale-reads", false, "allow to read metrics from a non-leader server",
 		)
 		noPeerMetricsEnabled            = flag.Bool("no-peer-metrics", false, "disable peer metrics collection")
+		noSerfMetricsEnabled            = flag.Bool("no-serf-metrics", false, "disable serf metrics collection")
 		noNodeMetricsEnabled            = flag.Bool("no-node-metrics", false, "disable node metrics collection")
 		noJobMetricsEnabled             = flag.Bool("no-jobs-metrics", false, "disable jobs metrics collection")
 		noAllocationsMetricsEnabled     = flag.Bool("no-allocations-metrics", false, "disable allocations metrics collection")
@@ -375,6 +406,7 @@ func main() {
 		client:                        apiClient,
 		AllowStaleReads:               *allowStaleReads,
 		PeerMetricsEnabled:            !*noPeerMetricsEnabled,
+		SerfMetricsEnabled:            !*noSerfMetricsEnabled,
 		NodeMetricsEnabled:            !*noNodeMetricsEnabled,
 		JobMetricEnabled:              !*noJobMetricsEnabled,
 		AllocationsMetricsEnabled:     !*noAllocationsMetricsEnabled,


### PR DESCRIPTION
This adds some interesting Serf metrics to the exporter:
- nomad_raft_applied_index
- nomad_raft_commit_index
- nomad_raft_fsm_pending
- nomad_raft_last_log_index
- nomad_raft_last_snapshot_index
- nomad_raft_num_peers

Based on version 0.0.7.

Closed #7.