### PR TITLE
Add extra label to metric so similar hostnames don't collide

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -258,7 +258,7 @@ func (e *Exporter) collectNodes(nodes nodeMap, ch chan<- prometheus.Metric) erro
 				}
 				ch <- prometheus.MustNewConstMetric(
 					serfLanMembersStatus, prometheus.GaugeValue, float64(state),
-					node.Datacenter, node.NodeClass, node.Name, drain,
+					node.Datacenter, node.NodeClass, node.Name, node.ID, drain,
 				)
 
 				if !nodes.IsReady(node.ID) {

--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -54,7 +54,7 @@ var (
 	serfLanMembersStatus = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "serf_lan_member_status"),
 		"Describe member state.",
-		[]string{"datacenter", "class", "node", "drain"}, nil,
+		[]string{"datacenter", "class", "node", "node_id", "drain"}, nil,
 	)
 	raftAppliedIndex = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "raft_applied_index"),


### PR DESCRIPTION
This PR adds `node_id` to every `serfLanMembersStatus` metric generated, which is a unique identifier and will avoid the collapse of this metric when there's two nodes (different id) with similar node name. It also solves https://github.com/pcarranza/nomad-exporter/issues/5

cc @pcarranza @omame 