### PR TITLE
Fix goreleaser syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,4 +45,6 @@ dockers:
     goarm: ''
     binary: nomad-exporter
     dockerfile: Dockerfile
-    latest: true
+    tag_templates:
+      - '{{ .Tag }}'
+      - latest


### PR DESCRIPTION
Goreleaser [has deprecated](https://goreleaser.com/deprecations/) the `latest` field in docker in favour of template variables. New goreleaser versions explode because of this.

This makes our manifest compatible.