### PR TITLE
Skip allocations which desired state is not equal to run

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -504,7 +504,12 @@ func (e *Exporter) collectAllocations(nodes nodeMap, ch chan<- prometheus.Metric
 					allocStub.Name, n.Name, n.Version)
 				return
 			}
-
+			if allocStub.DesiredStatus != "run" {
+				logrus.Debugf("Skipping fetching allocation %s because it's not desired to be run",
+					allocStub.Name)
+				return
+			}
+			
 			o = newLatencyObserver("get_allocation_info")
 			alloc, _, err := e.client.Allocations().Info(allocStub.ID, &api.QueryOptions{
 				AllowStale: true,


### PR DESCRIPTION
This should cause nomad-exporter to stop exporting metrics from allocations in `terminal` state.

Fetching and exporting metrics related to these allocations makes `nomad-exporter` start using high amounts of resources, and it has little purpose