### PR TITLE
Remove desired_status label

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -525,7 +525,6 @@ func (e *Exporter) collectAllocations(nodes nodeMap, ch chan<- prometheus.Metric
 
 			allocation.With(prometheus.Labels{
 				"status":         alloc.ClientStatus,
-				"desired_status": alloc.DesiredStatus,
 				"job_type":       *job.Type,
 				"job_id":         alloc.JobID,
 				"task_group":     alloc.TaskGroup,


### PR DESCRIPTION
This label is now useless, as it will be fixed to `run` after the change in https://github.com/pcarranza/nomad-exporter/pull/14