### PR TITLE
Actually remove desired_status label from nomad exporter metrics

### DIFF
--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -201,7 +201,6 @@ var (
 	},
 		[]string{
 			"status",
-			"desired_status",
 			"job_type",
 			"job_id",
 			"task_group",


### PR DESCRIPTION
After https://github.com/pcarranza/nomad-exporter/pull/15 was merged, nomad-exporter crashes upon start due to the metrics being built with less labels than the ones expected here.
They shouldn't be expected at all.
Nomad-exporter shouldn't be a datastore where a collection of dead jobs is kept. Its scope should be to provide observability over the allocations that the cluster _actually_ intends to run (and their interactions with resources).